### PR TITLE
[PSR4] Fix path, because src is empty real path is src/devvoh/fixedwidth/

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   },
   "autoload": {
     "psr-4": {
-      "Devvoh\\FixedWidth\\": "src/"
+      "Devvoh\\FixedWidth\\": "src/devvoh/fixedwidth/"
     }
   }
 }


### PR DESCRIPTION
I generate this PR because your path have 2 level of folders, and when use PSR4, doesn't locate files.  If you move files to src root folder, composer install works rigth, without errors.